### PR TITLE
fix:rebuild时异常ScrollController not attached to any scroll views

### DIFF
--- a/lib/src/transformer_page_view/transformer_page_view.dart
+++ b/lib/src/transformer_page_view/transformer_page_view.dart
@@ -506,7 +506,7 @@ class _TransformerPageViewState extends State<TransformerPageView> {
 
     if (_pageController.getRenderIndexFromRealIndex(_activeIndex) != index) {
       _fromIndex = _activeIndex = _pageController.initialPage;
-      if (!created) {
+      if (!created && _pageController.hasClients) {
         int initPage = _pageController.getRealIndexFromRenderIndex(index);
         _pageController.animateToPage(initPage,
             duration: widget.duration, curve: widget.curve);


### PR DESCRIPTION
当Swiper被StatefulWidget包装，切换index时会抛ScrollController not attached to any scroll views异常
![image](https://user-images.githubusercontent.com/5249360/126599759-ec489442-50b8-4b86-8ded-04cc5ad4fb33.png)
